### PR TITLE
Add CI with Codecov badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+  pull_request:
+    branches:
+      - main
+      - staging
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest --cov=. --cov-report xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# OpenBrand
+
+![CI](https://github.com/OpenBrandHQ/GapIntelligence/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/OpenBrandHQ/GapIntelligence/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenBrandHQ/GapIntelligence)
+
+This repository contains configuration files and documentation used by OpenBrand.

--- a/dummy.py
+++ b/dummy.py
@@ -1,0 +1,3 @@
+def add(a, b):
+    """Return the sum of a and b."""
+    return a + b

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,6 +3,10 @@
 
 Welcome to the OpenBrand GitHub repository. OpenBrand was formed through the integration of industry-leading companies: Gap Intelligence, Deep.ad, Traqline, and Competitive Promotion Report. We are committed to bringing clarity to the market through superior data analytics, web crawling technology, and LLM-driven insights.
 
+![CI](https://github.com/OpenBrandHQ/GapIntelligence/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/OpenBrandHQ/GapIntelligence/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenBrandHQ/GapIntelligence)
+
+
 **Official Website:** [openbrand.com](https://openbrand.com)
 
 ## About OpenBrand

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,0 +1,4 @@
+from dummy import add
+
+def test_add():
+    assert add(1, 2) == 3


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and upload coverage to Codecov
- create placeholder Python module and test
- display CI and coverage badges in README files
- trigger workflow on `staging` and `main` branches

## Testing
- `PYTHONPATH=. pytest tests/test_dummy.py -q`
- `PYTHONPATH=. pytest --cov=. --cov-report xml` *(fails: unrecognized arguments --cov)*


------
https://chatgpt.com/codex/tasks/task_e_68557f95e2148333806c63d0141b3cef