### PR TITLE
Fix CI and badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run tests
-        run: pytest --cov=. --cov-report xml
+        run: python -m pytest --cov=. --cov-report xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenBrand
 
-![CI](https://github.com/OpenBrandHQ/GapIntelligence/actions/workflows/ci.yml/badge.svg)
-[![codecov](https://codecov.io/gh/OpenBrandHQ/GapIntelligence/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenBrandHQ/GapIntelligence)
+![CI](https://github.com/GapIntelligence/.github/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/GapIntelligence/.github/branch/main/graph/badge.svg)](https://codecov.io/gh/GapIntelligence/.github)
 
 This repository contains configuration files and documentation used by OpenBrand.

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,8 +3,8 @@
 
 Welcome to the OpenBrand GitHub repository. OpenBrand was formed through the integration of industry-leading companies: Gap Intelligence, Deep.ad, Traqline, and Competitive Promotion Report. We are committed to bringing clarity to the market through superior data analytics, web crawling technology, and LLM-driven insights.
 
-![CI](https://github.com/OpenBrandHQ/GapIntelligence/actions/workflows/ci.yml/badge.svg)
-[![codecov](https://codecov.io/gh/OpenBrandHQ/GapIntelligence/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenBrandHQ/GapIntelligence)
+![CI](https://github.com/GapIntelligence/.github/actions/workflows/ci.yml/badge.svg)
+[![codecov](https://codecov.io/gh/GapIntelligence/.github/branch/main/graph/badge.svg)](https://codecov.io/gh/GapIntelligence/.github)
 
 
 **Official Website:** [openbrand.com](https://openbrand.com)


### PR DESCRIPTION
## Summary
- make `pytest` run via Python module so tests import local modules
- update README badges to use the `.github` repo
- update profile README badges as well
- badges now reference the GapIntelligence organization

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858160391d88333bcf7bf134d7fda32