### PR TITLE
Replace dummy module with MkDocs build test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains configuration files and documentation used by OpenBrand
 ## Documentation
 
 For an overview of the organization, visit the [profile README](profile/README.md).
+The MkDocs site is built from the files in the [`docs/`](docs/) directory.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 [![codecov](https://codecov.io/gh/GapIntelligence/.github/branch/main/graph/badge.svg)](https://codecov.io/gh/GapIntelligence/.github)
 
 This repository contains configuration files and documentation used by OpenBrand.
+
+## Documentation
+
+For an overview of the organization, visit the [profile README](profile/README.md).
+
+## Development
+
+This repository uses [MkDocs](https://www.mkdocs.org/) for documentation.
+Run the test suite (which also builds the site) with:
+
+```bash
+python -m pytest -q
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# OpenBrand Documentation
+
+This site contains documentation about the OpenBrand organization.
+
+For repository details, see the [main README](../README.md).
+
+Learn more about our organization on the [profile page](profile.md).

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -1,0 +1,3 @@
+# OpenBrand Profile
+
+This page mirrors the information in [profile/README.md](../profile/README.md).

--- a/dummy.py
+++ b/dummy.py
@@ -1,3 +1,0 @@
-def add(a, b):
-    """Return the sum of a and b."""
-    return a + b

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: OpenBrand Docs
+nav:
+  - Home: README.md
+  - Profile: profile/README.md
+docs_dir: .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: OpenBrand Docs
 nav:
-  - Home: README.md
-  - Profile: profile/README.md
-docs_dir: .
+  - Home: index.md
+  - Profile: profile.md
+docs_dir: docs

--- a/profile/README.md
+++ b/profile/README.md
@@ -59,4 +59,6 @@ To get started with development, please ensure you have access to the necessary 
 
 ---
 
+For repository configuration details, see the [main README](../README.md).
+
 Thank you for contributing to OpenBrand's continued success!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+mkdocs

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,4 +1,0 @@
-from dummy import add
-
-def test_add():
-    assert add(1, 2) == 3

--- a/tests/test_mkdocs.py
+++ b/tests/test_mkdocs.py
@@ -1,0 +1,15 @@
+import subprocess
+from pathlib import Path
+
+
+def test_mkdocs_build(tmp_path: Path) -> None:
+    """Ensure the mkdocs site builds successfully."""
+    site_dir = tmp_path / "site"
+    result = subprocess.run([
+        "mkdocs",
+        "build",
+        "--site-dir",
+        str(site_dir),
+    ], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert site_dir.exists()


### PR DESCRIPTION
## Summary
- remove `dummy.py` and its tests
- add MkDocs configuration and build test
- document MkDocs usage in README
- update dependencies

## Testing
- `python -m pytest -q` *(fails: FileNotFoundError: 'mkdocs')*

------
https://chatgpt.com/codex/tasks/task_e_68581900cf608333835a835e396fccf6